### PR TITLE
Upgrade to go-loggregator v2.0.0

### DIFF
--- a/vollocal/client_local.go
+++ b/vollocal/client_local.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 
 	"code.cloudfoundry.org/clock"
+	loggregator_v2 "code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/voldriver/driverhttp"
 	"code.cloudfoundry.org/volman"
-	"code.cloudfoundry.org/go-loggregator/loggregator_v2"
 	"github.com/tedsuo/ifrit/grouper"
 )
 

--- a/vollocal/client_local_test.go
+++ b/vollocal/client_local_test.go
@@ -8,10 +8,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	mfakes "code.cloudfoundry.org/go-loggregator/fakes"
 	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/volman/vollocal"
 	"code.cloudfoundry.org/volman/volmanfakes"
-	mfakes "code.cloudfoundry.org/go-loggregator/loggregator_v2/fakes"
 
 	"code.cloudfoundry.org/clock/fakeclock"
 	"code.cloudfoundry.org/lager"


### PR DESCRIPTION
Note that this PR is meant to go hand-in-hand with the following PRs:
- https://github.com/cloudfoundry/executor/pull/26
- https://github.com/cloudfoundry/rep/pull/14
- https://github.com/cloudfoundry/inigo/pull/17
- https://github.com/cloudfoundry/diego-release/pull/308

/cc @bradylove