### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/vollocal/client_local.go
+++ b/vollocal/client_local.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/clock"
-	loggregator_v2 "code.cloudfoundry.org/go-loggregator/compatibility"
+	loggingclient "code.cloudfoundry.org/diego-logging-client"
 	"code.cloudfoundry.org/lager"
 	"code.cloudfoundry.org/volman"
 	"github.com/Kaixiang/csiplugin"
@@ -43,11 +43,11 @@ func NewDriverConfig() DriverConfig {
 
 type localClient struct {
 	pluginRegistry volman.PluginRegistry
-	metronClient   loggregator_v2.IngressClient
+	metronClient   loggingclient.IngressClient
 	clock          clock.Clock
 }
 
-func NewServer(logger lager.Logger, metronClient loggregator_v2.IngressClient, config DriverConfig) (volman.Manager, ifrit.Runner) {
+func NewServer(logger lager.Logger, metronClient loggingclient.IngressClient, config DriverConfig) (volman.Manager, ifrit.Runner) {
 	clock := clock.NewClock()
 	registry := NewPluginRegistry()
 
@@ -62,7 +62,7 @@ func NewServer(logger lager.Logger, metronClient loggregator_v2.IngressClient, c
 	return NewLocalClient(logger, registry, metronClient, clock), grouper
 }
 
-func NewLocalClient(logger lager.Logger, registry volman.PluginRegistry, metronClient loggregator_v2.IngressClient, clock clock.Clock) volman.Manager {
+func NewLocalClient(logger lager.Logger, registry volman.PluginRegistry, metronClient loggingclient.IngressClient, clock clock.Clock) volman.Manager {
 	return &localClient{
 		pluginRegistry: registry,
 		metronClient:   metronClient,
@@ -116,7 +116,7 @@ func (client *localClient) Mount(logger lager.Logger, pluginId string, volumeId 
 	return mountResponse, nil
 }
 
-func sendMountDurationMetrics(logger lager.Logger, metronClient loggregator_v2.IngressClient, duration time.Duration, pluginId string) {
+func sendMountDurationMetrics(logger lager.Logger, metronClient loggingclient.IngressClient, duration time.Duration, pluginId string) {
 	err := metronClient.SendDuration(volmanMountDuration, duration)
 	if err != nil {
 		logger.Error("failed-to-send-volman-mount-duration-metric", err)
@@ -133,7 +133,7 @@ func sendMountDurationMetrics(logger lager.Logger, metronClient loggregator_v2.I
 	}
 }
 
-func sendUnmountDurationMetrics(logger lager.Logger, metronClient loggregator_v2.IngressClient, duration time.Duration, pluginId string) {
+func sendUnmountDurationMetrics(logger lager.Logger, metronClient loggingclient.IngressClient, duration time.Duration, pluginId string) {
 	err := metronClient.SendDuration(volmanUnmountDuration, duration)
 	if err != nil {
 		logger.Error("failed-to-send-volman-unmount-duration-metric", err)

--- a/vollocal/client_local_test.go
+++ b/vollocal/client_local_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	mfakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	mfakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/voldriver"
 	"code.cloudfoundry.org/volman/vollocal"
 	"code.cloudfoundry.org/volman/volmanfakes"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [benchmarkbbs](https://github.com/cloudfoundry/benchmarkbbs/pull/3)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [inigo](https://github.com/cloudfoundry/inigo/pull/18)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>